### PR TITLE
Redirection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SRC_FILES = main.c
 # Parser source files (in src/parser/)
 SRC_PARSER = cmd_list.c file_to_list.c parser_helper.c parser.c parser_test.c
 # Executor source files (in src/executor/)
-SRC_EXECUTOR = exec.c external_exec.c
+SRC_EXECUTOR = exec.c external_exec.c redirections.c
 # Builtins source files (in src/builtins)
 SRC_BUILTINS = execute_builtins.c pwd.c echo.c cd.c env.c env_help.c export.c unset.c exit.c
 # Error handler source files (in src/error/)

--- a/includes/execution.h
+++ b/includes/execution.h
@@ -6,7 +6,7 @@
 /*   By: mimalek <mimalek@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/04 18:50:45 by mimalek           #+#    #+#             */
-/*   Updated: 2025/05/08 17:39:04 by mimalek          ###   ########.fr       */
+/*   Updated: 2025/05/13 10:08:40 by mimalek          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,4 +20,5 @@
 void	test_execute(t_env_list *env_list, t_cmd_node *node);
 void	execute_builtin(t_cmd_node *node, t_env_list *env_list);
 void	execute_external(t_cmd_node *node, t_env_list *env_list);
+void	execute_redirections(t_file_list *file_list);
 #endif

--- a/includes/execution.h
+++ b/includes/execution.h
@@ -6,7 +6,7 @@
 /*   By: mimalek <mimalek@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/04 18:50:45 by mimalek           #+#    #+#             */
-/*   Updated: 2025/05/13 10:08:40 by mimalek          ###   ########.fr       */
+/*   Updated: 2025/05/13 10:58:36 by mimalek          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 # include "env.h"
 # include <stdbool.h>
 
-void	test_execute(t_env_list *env_list, t_cmd_node *node);
+void	execute(t_env_list *env_list, t_cmd_node *node);
 void	execute_builtin(t_cmd_node *node, t_env_list *env_list);
 void	execute_external(t_cmd_node *node, t_env_list *env_list);
 void	execute_redirections(t_file_list *file_list);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -36,6 +36,7 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <unistd.h>
+# include <fcntl.h>
 
 # include "tokenizer.h"
 # include "parser.h"

--- a/src/executor/exec.c
+++ b/src/executor/exec.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mimalek <mimalek@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/02 12:29:48 by lihrig            #+#    #+#             */
+/*   Updated: 2025/05/13 10:58:46 by mimalek          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	execute(t_env_list *env_list, t_cmd_node *node)
+{
+	int	stdin;
+	int	stdout;
+
+	stdin = dup(STDIN_FILENO);
+	stdout = dup(STDOUT_FILENO);
+
+	if (node->file)
+	{
+		execute_redirections(node->file);
+	}
+	if (node->cmd_type == CMD_BUILTIN)
+	{
+		execute_builtin(node, env_list);
+	}
+	else if (node->cmd_type == CMD_SIMPLE)
+	{
+		execute_external(node, env_list);
+	}
+	dup2(stdin, STDIN_FILENO);
+	dup2(stdout, STDOUT_FILENO);
+	close(stdin);
+	close(stdout);
+}

--- a/src/executor/redirections.c
+++ b/src/executor/redirections.c
@@ -1,0 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirections.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mimalek <mimalek@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/13 09:30:29 by mimalek           #+#    #+#             */
+/*   Updated: 2025/05/13 10:12:59 by mimalek          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static void	redirect_fd(char *filename, int flags, int std);
+
+void	execute_redirections(t_file_list *file_list)
+{
+	t_file_node	*current_file;
+
+	current_file = file_list->head;
+	while (current_file)
+	{
+		if (current_file->redirection_type == REDIR_IN)
+			redirect_fd(current_file->name, O_RDONLY, STDIN_FILENO);
+		else if (current_file->redirection_type == REDIR_OUT)
+			redirect_fd(current_file->name, O_WRONLY | O_CREAT | O_TRUNC, STDOUT_FILENO);
+		else if (current_file->redirection_type == REDIR_APPEND)
+			redirect_fd(current_file->name, O_WRONLY | O_CREAT | O_APPEND, STDOUT_FILENO);
+		current_file = current_file->next;
+	}
+}
+
+static void	redirect_fd(char *filename, int flags, int std)
+{
+	int	fd;
+
+	fd = open(filename, flags, 0644);
+	if (fd == -1)
+	{
+		perror(filename);
+		exit(EXIT_FAILURE);
+	}
+	if (dup2(fd, std) == -1)
+	{
+		perror("dup2");
+		close(fd);
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+}

--- a/src/executor/redirections.c
+++ b/src/executor/redirections.c
@@ -6,13 +6,14 @@
 /*   By: mimalek <mimalek@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/13 09:30:29 by mimalek           #+#    #+#             */
-/*   Updated: 2025/05/13 10:12:59 by mimalek          ###   ########.fr       */
+/*   Updated: 2025/05/13 11:32:39 by mimalek          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 static void	redirect_fd(char *filename, int flags, int std);
+static void	setup_heredoc(char *delimiter);
 
 void	execute_redirections(t_file_list *file_list)
 {
@@ -27,6 +28,8 @@ void	execute_redirections(t_file_list *file_list)
 			redirect_fd(current_file->name, O_WRONLY | O_CREAT | O_TRUNC, STDOUT_FILENO);
 		else if (current_file->redirection_type == REDIR_APPEND)
 			redirect_fd(current_file->name, O_WRONLY | O_CREAT | O_APPEND, STDOUT_FILENO);
+		else if (current_file->redirection_type == REDIR_HEREDOC)
+			setup_heredoc(current_file->name);
 		current_file = current_file->next;
 	}
 }
@@ -48,4 +51,31 @@ static void	redirect_fd(char *filename, int flags, int std)
 		exit(EXIT_FAILURE);
 	}
 	close(fd);
+}
+
+static void	setup_heredoc(char *delimiter)
+{
+	char	*line;
+	int		heredoc_pipe[2];
+
+	if (pipe(heredoc_pipe) == -1)
+	{
+		perror("pipe");
+		exit(EXIT_FAILURE);
+	}
+	while (1)
+	{
+		line = readline("> ");
+		if (!line || ft_strncmp(line, delimiter, ft_strlen(line) + 1) == 0)
+		{
+			free(line);
+			break;
+		}
+		write(heredoc_pipe[1], line, ft_strlen(line));
+		write(heredoc_pipe[1], "\n", 1);
+		free(line);
+	}
+	close(heredoc_pipe[1]);
+	dup2(heredoc_pipe[0], STDIN_FILENO);
+	close(heredoc_pipe[0]);
 }


### PR DESCRIPTION
**### Description:**

This PR adds the handling of input/output redirections (including append and heredoc) during the command execution phase of the minishell. The changes focus specifically on executing commands with redirections (such as >, >>, <, and <<), ensuring that file descriptors are properly managed and that redirection is correctly applied before execution.

**Key Changes:**

- **Redirection Execution Logic:**

- Added the execute_redirections() function, which handles the redirection of input/output for commands based on redirection types:

    -   Input Redirection (<): Reads from a file and redirects the input to the command.
    
    -   Output Redirection (>): Redirects the output of a command to a file, overwriting it.
    
    -   Output Append (>>): Appends the output of a command to a file.
    
    -   Heredoc (<<): Redirects the input from the user, capturing input until a delimiter is encountered.

- For each redirection type, the corresponding file descriptor is opened using the open() system call and redirected using dup2().

- **Heredoc Management:**

- Implemented setup_heredoc() to handle << redirections by reading from user input until the specified delimiter is encountered and redirecting this input to the command.

- **File Descriptor Management:**

- Correctly closes and redirects file descriptors for each redirection type, ensuring that input and output streams are handled as expected during command execution.

**Changes Made:**

- Added a redirect_fd() helper function to reduce code duplication when handling redirection.

- Updated the execution logic to apply redirection before command execution, allowing the shell to correctly process input/output streams.

- Integrated dup2() calls to ensure the file descriptors are redirected to the correct input/output streams.

**Testing:**

- Input Redirection (<): Ensures that input is read from a specified file instead of the terminal.

- Output Redirection (>): Ensures that the output is written to a file, overwriting it.

- Append Redirection (>>): Ensures that the output is appended to an existing file.

- Heredoc (<<): Works as expected, capturing user input until a delimiter is reached and redirecting it into the command.